### PR TITLE
Fix cmake for Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ On macOS, Apple is rude and won't let you link with the system-provided `libcryp
 you need to `brew install openssl` (or build it yourself). Then you can pretend you have a
 real unix system:
 
-    cmake -B build -DOPENSSL_ROOT_PATH=/usr/local/opt/openssl && cmake --build build
+    cmake -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl && cmake --build build
 
 ### Windows
 On Windows, you need to compile `libgit2` and `OpenSSL` yourself. Then just point `cmake`


### PR DESCRIPTION
With `cmake -B build -DOPENSSL_ROOT_PATH=/usr/local/opt/openssl`, I am getting below error:
```cmake
CMake Error at /usr/local/Cellar/cmake/3.20.5/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
  Could NOT find OpenSSL, try to set the path to OpenSSL root folder in the
  system variable OPENSSL_ROOT_DIR (missing: OPENSSL_CRYPTO_LIBRARY
  OPENSSL_INCLUDE_DIR)
```

With `cmake -B build -DOPENSSL_ROOT_DIR=/usr/local/opt/openssl`, its working fine. I am using `cmake version 3.20.5`