### PR TITLE
Fix "Unknown armor header" gpg message for signed commits

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -123,7 +123,7 @@ I should not be allowed near this
 		}
 	} else {
 		// Yes it is: insert nonce as a header in the GPG signature
-		nonce_insert = strstr(gpgsig, "\n");
+		nonce_insert = strstr(gpgsig, "\n\n");
 
 		memcpy(modified_commit, base_body, nonce_insert - base_body);
 		commit_size += nonce_insert - base_body;


### PR DESCRIPTION
Using Git CLI like this:

```
git log --show-signature
```

Right now it shows a message like `gpg: unknown armor header: Nonce: UXS^O      AAAAA1316` (please see the screenshot).

MR fixes this, you can pull my commit to compare it against yours locally.<br>
I'm not sure the fix is _clearly_ correct, but it works also for other commits.

<details>
<summary>Screenshot</summary>

![image](https://user-images.githubusercontent.com/8993851/202035604-1b1bcf7d-1e55-4f36-b515-dbd82e43cef0.png)

</details>